### PR TITLE
fix: 작업이 없을 때 CSV 내보내기 버튼 비활성화

### DIFF
--- a/components/tasks/task-list-toolbar.tsx
+++ b/components/tasks/task-list-toolbar.tsx
@@ -11,9 +11,10 @@ import type { TaskView } from './task-view-container';
 type Props = {
   view: TaskView;
   onViewChange: (view: TaskView) => void;
+  taskCount: number;
 };
 
-export function TaskListToolbar({ view, onViewChange }: Props) {
+export function TaskListToolbar({ view, onViewChange, taskCount }: Props) {
   const [createOpen, setCreateOpen] = useState(false);
   const [exporting, startExport] = useTransition();
   const [importText, setImportText] = useState<string | null>(null);
@@ -92,7 +93,12 @@ export function TaskListToolbar({ view, onViewChange }: Props) {
           <Button colorPalette="blue" onClick={() => setCreateOpen(true)}>
             + 작업 추가
           </Button>
-          <Button variant="outline" onClick={handleExport} loading={exporting}>
+          <Button
+            variant="outline"
+            onClick={handleExport}
+            loading={exporting}
+            disabled={taskCount === 0}
+          >
             CSV 내보내기
           </Button>
           <Button variant="outline" onClick={handleImportClick}>

--- a/components/tasks/task-view-container.tsx
+++ b/components/tasks/task-view-container.tsx
@@ -14,7 +14,7 @@ export function TaskViewContainer({ nodes }: { nodes: TaskNode[] }) {
 
   return (
     <>
-      <TaskListToolbar view={view} onViewChange={setView} />
+      <TaskListToolbar view={view} onViewChange={setView} taskCount={nodes.length} />
       {nodes.length === 0 ? (
         <TaskListEmpty />
       ) : view === 'list' ? (

--- a/tests/e2e/feature-f.spec.ts
+++ b/tests/e2e/feature-f.spec.ts
@@ -73,25 +73,10 @@ test.describe('기능 F — CSV 가져오기/내보내기', () => {
     expect(parentLine).toContain('"진행 중"');
   });
 
-  test('J10-empty: 작업이 없을 때도 CSV 내보내기가 헤더만 포함한 파일을 만든다', async ({
-    page,
-  }) => {
+  test('J10-empty: 작업이 없을 때 CSV 내보내기 버튼이 비활성화된다', async ({ page }) => {
     await page.goto('/');
 
-    const downloadPromise = page.waitForEvent('download');
-    await page.getByRole('button', { name: 'CSV 내보내기' }).click();
-    const download = await downloadPromise;
-
-    const downloadPath = await download.path();
-    const fs = await import('node:fs/promises');
-    const raw = await fs.readFile(downloadPath, 'utf-8');
-    const text = raw.slice(UTF8_BOM.length);
-    const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
-
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toBe(
-      '"제목","설명","담당자","상태","진행률","시작일","목표 기한","상위 작업 제목"'
-    );
+    await expect(page.getByRole('button', { name: 'CSV 내보내기' })).toBeDisabled();
   });
 
   test('J11: CSV 가져오기 정상 — 3건 추가, 계층 연결', async ({ page }) => {


### PR DESCRIPTION
## Summary
- 작업이 0개일 때 헤더만 들어 있는 빈 CSV가 다운로드되어 혼란을 주던 문제를 막음
- `TaskListToolbar`에 `taskCount` prop을 추가하고, 0일 때 **CSV 내보내기** 버튼을 `disabled` 처리
- E2E 테스트 `J10-empty`를 "버튼이 비활성화된다" 검증으로 교체 (다운로드 시도 → disabled 단언)

## Test plan
- [ ] `npm run lint` 통과 확인
- [ ] 로컬에서 작업이 하나도 없는 상태로 `/`에 진입 → **CSV 내보내기** 버튼이 회색으로 비활성화되는지 확인
- [ ] 작업 1개 추가 후 같은 버튼이 활성화되고, 클릭 시 정상적으로 CSV가 다운로드되는지 확인
- [ ] `npx playwright test feature-f.spec.ts` (또는 J10/J10-empty 단독)로 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)