### PR TITLE
feat: 완료 상태 작업 제목에 취소선 적용

### DIFF
--- a/components/tasks/task-list-gantt.tsx
+++ b/components/tasks/task-list-gantt.tsx
@@ -93,6 +93,7 @@ export function TaskListGantt({ nodes }: { nodes: TaskNode[] }) {
               textOverflow="ellipsis"
               whiteSpace="nowrap"
               title={node.task.title}
+              textDecoration={node.task.status === 'done' ? 'line-through' : undefined}
             >
               {node.task.title}
             </Box>

--- a/components/tasks/task-row.tsx
+++ b/components/tasks/task-row.tsx
@@ -75,7 +75,13 @@ export function TaskRow({ task, depth, hasChildren, expanded, onToggle }: Props)
               // 자식이 없으면 같은 폭의 spacer로 정렬 유지
               <span style={{ width: '1rem', display: 'inline-block' }} />
             )}
-            <span>{task.title}</span>
+            <span
+              style={{
+                textDecoration: task.status === 'done' ? 'line-through' : undefined,
+              }}
+            >
+              {task.title}
+            </span>
           </HStack>
         </Table.Cell>
         <Table.Cell>{task.assignee ?? '—'}</Table.Cell>


### PR DESCRIPTION
## Summary
- 작업 status가 `done`일 때 제목 텍스트에 `line-through`를 적용해, "끝난 일"을 한눈에 구별 가능하게 함
- 목록 뷰: `task-row.tsx`의 제목 `<span>`에 조건부 `textDecoration` 인라인 스타일 추가
- 간트 뷰: `task-list-gantt.tsx`의 좌측 라벨 `<Box>`에 조건부 `textDecoration` Chakra prop 추가
- 글자 색·두께는 그대로 유지 (취소선만)

## Test plan
- [ ] `npm run lint` 통과 확인
- [ ] 작업 3개를 각각 todo / doing / done 으로 만들고, 목록 뷰에서 done 행만 제목에 취소선이 그어지는지 확인
- [ ] 간트 뷰로 전환해 좌측 라벨에서도 done 행만 취소선이 적용되는지 확인
- [ ] 상태 배지를 클릭해 다른 상태 → done 으로 바꾸면 취소선이 즉시 켜지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)